### PR TITLE
Fix conflicting keybinds with NES

### DIFF
--- a/package.json
+++ b/package.json
@@ -1075,7 +1075,7 @@
       {
         "command": "vscode-texttoolbox.TabOut",
         "key": "tab",
-        "when": "editorTextFocus && !suggestWidgetVisible && !inlineSuggestionVisible && !inSnippetMode && !editorHasMultipleSelections"
+        "when": "editorTextFocus && !suggestWidgetVisible && !inlineSuggestionVisible && !inSnippetMode && !editorHasMultipleSelections && !inlineEditIsVisible && !tabShouldJumpToInlineEdit"
       },
       {
         "command": "vscode-texttoolbox.SelectTextBetweenBrackets",


### PR DESCRIPTION
Fixes #51

Updates the `when` expression for the `vscode-texttoolbox.TabOut` keybinding to avoid conflicts with Github Copilot's Next Edit Suggestion feature.